### PR TITLE
Refactor: create user blueprint and migrate auth routes

### DIFF
--- a/flashlearn/__init__.py
+++ b/flashlearn/__init__.py
@@ -63,7 +63,7 @@ def create_app(config = None):
     db.init_with_ctx(app)  # Initialize Db with the app context
     app.teardown_appcontext(db.close_session)
 
-    from flashlearn.auth import bp
+    from flashlearn.user import bp, routes
     app.register_blueprint(bp)
 
     from flashlearn.core import bp, routes

--- a/flashlearn/core/routes.py
+++ b/flashlearn/core/routes.py
@@ -1,7 +1,7 @@
 from flask import request, url_for, jsonify, flash, g, redirect, abort
 from sqlalchemy.sql.expression import func
 from flashlearn.core import bp
-from flashlearn.models import User, Card, Deck, StudyPlan
+from flashlearn.models import Card, Deck, StudyPlan
 from flashlearn.decorators import login_required
 from flashlearn.enums import OrderTypeEnum
 
@@ -147,22 +147,6 @@ def reset_deck(deck_id):
 	return jsonify('OK')
 
 
-@bp.route('/users')
-def list_users():
-	users = [user.to_json for user in User.all()]
-	return jsonify(users)
-
-
-@bp.route('/user/<int:user_id>')
-def get_user(user_id):
-	if request.method == 'GET':
-		user = User.get_by_id(user_id)
-		if user is None:
-			return 'User not found', 404
-		return jsonify(User.get_by_id(user_id).to_json)
-	return jsonify('Invalid request ')
-
-
 @bp.route('/plans', methods = ('GET', 'POST'))
 def list_study_plans():
 	plans = [plan.to_json for plan in StudyPlan.all()]
@@ -214,10 +198,3 @@ def get_next_card():
 		return jsonify(card.to_json)
 	flash('You have studied all cards in this deck')
 	return 'OK'
-
-
-@bp.route('user/<int:user_id>/delete', methods = ('GET', 'POST'))
-def delete_user(user_id):
-	user = User.query.filter_by(id = user_id, state = 'active').first()
-	user.delete()
-	return 'deleted'

--- a/flashlearn/decorators.py
+++ b/flashlearn/decorators.py
@@ -12,6 +12,6 @@ def login_required(view):
 			if len(view.__module__.split(".")) > 2:
 				bp = (view.__module__.split(".")[1])  # Get the blueprint name, for accurate urls.
 				view_name = f'{bp}.{view_name}'
-			return redirect(url_for('auth.login', next = url_for(view_name)))
+			return redirect(url_for('user.login', next = url_for(view_name)))
 		return view(**kwargs)
 	return wrapped_view

--- a/flashlearn/models.py
+++ b/flashlearn/models.py
@@ -35,7 +35,7 @@ class TimestampedModel(db.Base):
 
 	@classmethod
 	def all(cls):
-		return cls.query.filter(cls.state == 'Active')
+		return cls.query.filter(cls.state == 'active')
 
 	@classmethod
 	def get_by_id(cls, _id):
@@ -72,7 +72,7 @@ class User(TimestampedModel):
 			date_created = http_date(self.date_created), date_modified = http_date(self.date_updated),
 			decks = [d.to_json for d in self.decks],
 			study_plans = [p.to_json for p in self.study_plans],
-			is_active = True if self.state == 'Active' else False)
+			is_active = True if self.state == 'active' else False)
 
 	def __repr__(self):
 		return f'<User: {self.username} - {self.state}>'

--- a/flashlearn/user/__init__.py
+++ b/flashlearn/user/__init__.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+
+bp = Blueprint(
+	'user',
+	__name__,
+	url_prefix = '/user',
+	static_folder = 'static',
+	template_folder = 'templates'
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,11 @@ class BaseTestCase(unittest.TestCase):
 			username = self.alice.username
 			password = 'password'
 		return self.client.post(
-			'/auth/login', data = dict(username = username, password = password),
+			'/user/login', data = dict(username = username, password = password),
 			follow_redirects = True)
 
 	def logout(self):
-		return self.client.post('/auth/logout')
+		return self.client.post('/user/logout')
 
 	@staticmethod
 	def refresh(*args):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,12 +6,12 @@ class TestAuth(BaseTestCase):
 	"""Auth blueprint test class"""
 
 	def test_get_login(self):
-		res = self.client.get('auth/login')
+		res = self.client.get('user/login')
 		self.assertEqual(200, res.status_code)
 		self.assertIn(b'Login Route', res.data)
 
 	def test_get_register(self):
-		res = self.client.get('auth/register')
+		res = self.client.get('user/register')
 		self.assertEqual(200, res.status_code)
 		self.assertIn(b'Register Route', res.data)
 
@@ -26,7 +26,7 @@ class TestAuth(BaseTestCase):
 
 	def test_register_pass(self):
 		res = self.client.post(
-			'auth/register', data = {
+			'user/register', data = {
 				'username': 'testuser', 'password': 'pass@134#', 'email': 'mail@example.com'
 			}, follow_redirects = True)
 		self.assertEqual(200, res.status_code)
@@ -36,7 +36,7 @@ class TestAuth(BaseTestCase):
 
 	def test_register_fail(self):
 		res = self.client.post(
-			'auth/register', data = {
+			'user/register', data = {
 				'username': 'alice', 'email': ''
 			}, follow_redirects = True)
 		self.assertEqual(200, res.status_code)


### PR DESCRIPTION
- Created user blueprint and migrated auth routes to the new blueprint.
- App wide refactor to replace /auth prefixed urls with /user.
- Add tests for get_user, list_users and delete_user routes