### PR TITLE
add alembic migration

### DIFF
--- a/flashlearn/__init__.py
+++ b/flashlearn/__init__.py
@@ -1,8 +1,8 @@
 import os
 import logging
-from logging.handlers import RotatingFileHandler
-from flask import Flask, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+from flask import Flask, redirect, url_for
+from logging.handlers import RotatingFileHandler
 from instance.config import app_config
 from flashlearn.decorators import login_required
 
@@ -61,18 +61,20 @@ def create_app(config=None):
         # TODO: Add index code
         return redirect(url_for("core.decks"))
 
-    from flashlearn.commands import register_commands
-
-    register_commands(app)  # Register app cli commands
+    # Initialize db with app instance
     db.init_app(app)
-    register_blueprints(app)
+
+    # Commands and Blueprint registration needs to be after db init..
+    register_blueprints_and_commands(app)
 
     return app
 
 
-def register_blueprints(app):
+def register_blueprints_and_commands(app):
     from flashlearn.user import user, routes
     from flashlearn.core import core, routes  # noqa
+    from flashlearn.commands import register_commands
 
+    register_commands(app)
     app.register_blueprint(user)
     app.register_blueprint(core)

--- a/flashlearn/commands.py
+++ b/flashlearn/commands.py
@@ -1,4 +1,5 @@
 import click
+from flask_migrate import Migrate, MigrateCommand
 from flask.cli import with_appcontext
 from flashlearn import db
 
@@ -6,8 +7,11 @@ from flashlearn import db
 @click.command("init-db")
 @with_appcontext
 def init_db_command():
+    """
+    Initialize a local database on devevelopment
+    """
     confirm = click.prompt(
-        "The database will be re-defined." "\nReply with Y/N to confirm or cancel",
+        "The database will be re-initialized." "\nReply with Y/N to confirm or cancel",
         type=str,
     )
     if confirm.lower() == "y":
@@ -17,51 +21,55 @@ def init_db_command():
         click.echo("Cancelled db init.")
 
 
-@click.command("clear-db")
+@click.command("drop-all")
 @with_appcontext
-def clear_db_command():
+def drop_all_command():
+    """
+    Drop all tables on current env
+    Don't use this command on production
+    """
     confirm = click.prompt(
-        "All database tables will be dropped and all data will be lost."
-        "\nReply with Y/N to confirm or cancel.",
+        "All database tables will be dropped." "\nReply with Y/N to confirm or cancel.",
         type=str,
     )
     if confirm.lower() == "y":
         db.drop_all()
         click.echo("All database tables successfully deleted.")
     else:
-        click.echo("Cancelled clear-db.")
-
-
-def prompt_password():
-    password = click.prompt("Password", type=str, hide_input=True)
-    password_2 = click.prompt("Confirm your password", type=str, hide_input=True)
-    if password == password_2:
-        return password
-    else:
-        click.echo("Passwords do not match. Try again.")
-        prompt_password()
+        click.echo("Cancelled drop-all.")
 
 
 @click.command("create-user")
 @with_appcontext
 def create_user_command():
+    """Quick create a user for development env"""
+
     from flashlearn.models import User
 
     username = click.prompt("Username", type=str)
     if User.query.filter_by(username=username).first() is None:
-        password = prompt_password()
+        password = click.prompt(
+            "Password",
+            type=str,
+            hide_input=True,
+            confirmation_prompt=True,
+        )
         email = click.prompt("Email", default=None)
         u = User(username=username, password=password, email=email)
         u.save()
         click.echo("User created successfully.")
     else:
-        click.echo("Username already in use. Try again with a different one.")
+        click.echo("Username not available. Try again with a different one.")
 
 
 def register_commands(app):
     """
-    Registers custom CLI commands via click.
+    Registers custom CLI commands via click withing the app context..
     """
+    # Setup Alembic Migrations
+    Migrate(app, db)
+    app.cli.add_command(MigrateCommand, name="db")
+
     app.cli.add_command(init_db_command)
-    app.cli.add_command(clear_db_command)
+    app.cli.add_command(drop_all_command)
     app.cli.add_command(create_user_command)

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,45 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,96 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from flask import current_app
+config.set_main_option(
+    'sqlalchemy.url',
+    str(current_app.extensions['migrate'].db.engine.url).replace('%', '%%'))
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions['migrate'].configure_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-pytest==6.0.1
-Flask==1.1.2
 Flask_SQLAlchemy==2.4.4
+Flask_Migrate==2.5.3
 Flask_Bcrypt==0.7.1
 Werkzeug==1.0.1
 click==7.1.2
+Flask==1.1.2
+alembic==1.4.3
 SQLAlchemy==1.3.18
-black==20.8b1
+pytest==6.0.1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,10 +6,10 @@ class TestCommands:
         res = cli_runner.invoke(args=["init-db"], input="N")
         assert "Cancelled db init" in res.output, "Should cancel db initialization"
 
-    def test_clear_db(self, test_app):
+    def test_drop_tables(self, test_app):
         cli_runner = test_app.test_cli_runner()
-        res = cli_runner.invoke(args=["clear-db"], input="N")
-        assert "Cancelled clear-db" in res.output, "Should cancel drop all command"
+        res = cli_runner.invoke(args=["drop-all"], input="N")
+        assert "Cancelled drop-all" in res.output, "Should cancel drop all command"
 
     def test_create_user(self, test_app):
         with test_app.app_context():


### PR DESCRIPTION
- Add Alembic for Flask-SqlAlchemy migrations
- Register db migration command via click
- Redefined drop-all command to be explicitly about table deletion and not data clearing
- Updated password prompt flow in create-user command